### PR TITLE
Update actions/setup-node to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Cache Node.js modules
-      uses: actions/cache@v1
-      with:
-        path: ${{ github.workspace }}/node_modules
-        key: ${{ runner.OS }}-${{ matrix.node-version}}-node_modules-${{ hashFiles('yarn.lock') }}
+        cache: yarn
     - run: yarn --frozen-lockfile
     - run: yarn test --coverage
     - name: Create coverage report flag


### PR DESCRIPTION
This version includes a caching feature, so the actions/cache usage can be removed, which is convenient because it will stop working in February.